### PR TITLE
Fix JDK 13 bug

### DIFF
--- a/MarioAI4J/src/ch/idsia/benchmark/mario/engine/LevelRenderer.java
+++ b/MarioAI4J/src/ch/idsia/benchmark/mario/engine/LevelRenderer.java
@@ -132,7 +132,7 @@ public class LevelRenderer {
 							- yCam - yo + LevelScene.cellSize);
 				}
 
-				if (((Level.TILE_BEHAVIORS[b & 0xff]) & Level.BIT_ANIMATED) > 0) {
+				if (((Level.TILE_BEHAVIORS[b & 0xff]) & Level.BIT_ANIMATED) == Level.BIT_ANIMATED) {
 					int animTime = (tick / 3) % 4;
 
 					if ((b % 16) / 4 == 0 && b / 16 == 1) {


### PR DESCRIPTION
This PR adds a workaround for a bug in JRE 13 (most likely also in 12, but was not tested) which caused the tiles to disappear after some time. The bug seems to be caused by JIT doing wrong optimizations. The same can be achieved by many other bitwise operations but this seems to be the cleanest one.

Jointly fixed by me and [Jana Řežábková](https://github.com/janarez).