### PR TITLE
Fix maven build file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,16 @@
     </properties>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+        </plugins>
         <sourceDirectory>src</sourceDirectory>
 
         <resources>


### PR DESCRIPTION
When building project from command line `mvn install` command throws an error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project marioai4j: Fatal error compiling: error: invalid target release: 1.11 -> [Help 1]
```

This is solved by adding `maven-compiler-plugin` to the `pom.xml` 